### PR TITLE
Add Sendable support

### DIFF
--- a/Sources/Get/APIClient.swift
+++ b/Sources/Get/APIClient.swift
@@ -2,7 +2,11 @@
 //
 // Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
 
+#if compiler(>=5.6)
 @preconcurrency import Foundation
+#else
+import Foundation
+#endif
 
 public protocol APIClientDelegate: Sendable {
     func client(_ client: APIClient, willSendRequest request: inout URLRequest) async throws

--- a/Sources/Get/Helpers.swift
+++ b/Sources/Get/Helpers.swift
@@ -2,7 +2,11 @@
 //
 // Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
 
+#if compiler(>=5.6)
 @preconcurrency import Foundation
+#else
+import Foundation
+#endif
 
 struct AnyEncodable: Encodable {
     private let value: Encodable

--- a/Sources/Get/Request.swift
+++ b/Sources/Get/Request.swift
@@ -2,9 +2,9 @@
 //
 // Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
 
-import Foundation
+@preconcurrency import Foundation
 
-public struct Request<Response> {
+public struct Request<Response>: Sendable {
     public var method: String
     public var path: String
     public var query: [(String, String?)]?
@@ -99,3 +99,5 @@ public struct Response<T> {
         Response<U>(value: closure(value), data: data, request: request, response: response, metrics: metrics)
     }
 }
+
+extension Response: Sendable where T: Sendable {}

--- a/Sources/Get/Request.swift
+++ b/Sources/Get/Request.swift
@@ -2,7 +2,11 @@
 //
 // Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
 
+#if compiler(>=5.6)
 @preconcurrency import Foundation
+#else
+import Foundation
+#endif
 
 public struct Request<Response>: Sendable {
     public var method: String


### PR DESCRIPTION
- Conform internal models to Sendable. 
- There are two classes which are unchecked Sendables and use an NSLock to manage access to the mutable values, which seems to be the recommended way according to the Swift forums.

Tests pass locally. Of course, the alternative is that we could just `@preconcurrency import Get`, but.. going to need proper support anyway and the locking mechanisms fix potential data races that exist today.