### PR TITLE
Running tests on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run Tests
         run: swift test
+
+  linux-run-tests:
+    name: Unit Tests (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Tests
+        run: swift test

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "Mocker",
-        "repositoryURL": "https://github.com/vox-humana/Mocker.git",
+        "repositoryURL": "https://github.com/WeTransfer/Mocker.git",
         "state": {
-          "branch": "master",
-          "revision": "9b2a6f7de644aeb73ae2114f102d5466874df0fa",
-          "version": null
+          "branch": null,
+          "revision": "5b270d79f39f6628f4c87752f7470ba640e09cba",
+          "version": "2.5.6"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "Mocker",
-        "repositoryURL": "https://github.com/WeTransfer/Mocker.git",
+        "repositoryURL": "https://github.com/vox-humana/Mocker.git",
         "state": {
-          "branch": null,
-          "revision": "352066f1a29108548386487ae083b4115e94c1fb",
-          "version": "2.5.4"
+          "branch": "master",
+          "revision": "9b2a6f7de644aeb73ae2114f102d5466874df0fa",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Get", targets: ["Get"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/WeTransfer/Mocker.git", from: "2.3.0")
+        .package(url: "https://github.com/vox-humana/Mocker.git", branch: "master")
     ],
     targets: [
         .target(name: "Get"),

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "Get", targets: ["Get"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vox-humana/Mocker.git", branch: "master")
+        .package(url: "https://github.com/WeTransfer/Mocker.git", from: "2.5.6")
     ],
     targets: [
         .target(name: "Get"),

--- a/Tests/GetTests/ClientAuthorizationTests.swift
+++ b/Tests/GetTests/ClientAuthorizationTests.swift
@@ -4,6 +4,9 @@
 
 import XCTest
 import Mocker
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @testable import Get
 
 final class APIClientAuthorizationTests: XCTestCase {

--- a/Tests/GetTests/ClientTests.swift
+++ b/Tests/GetTests/ClientTests.swift
@@ -42,9 +42,11 @@ final class APIClientTests: XCTestCase {
         XCTAssertEqual(response.data.count, 1321)
         XCTAssertEqual(response.request.url, url)
         XCTAssertEqual(response.statusCode, 200)
+#if !os(Linux)
         let metrics = try XCTUnwrap(response.metrics)
         let transaction = try XCTUnwrap(metrics.transactionMetrics.first)
         XCTAssertEqual(transaction.request.url, URL(string: "https://api.github.com/user")!)
+#endif
     }
     
     func testCancellingRequests() async throws {

--- a/Tests/GetTests/GitHubAPI.swift
+++ b/Tests/GetTests/GitHubAPI.swift
@@ -3,6 +3,9 @@
 // Copyright (c) 2021-2022 Alexander Grebenyuk (github.com/kean).
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Get
 
 // An example of an API definition. Feel free to use any other method for


### PR DESCRIPTION
Linux support was introduced here #20 However, because there is no CI task that would sanitise every single PR it might get broken easily.
This PR adds a simple `swift test` job that runs on Linux.
Had to add Linux support in [Mocker](https://github.com/WeTransfer/Mocker/pull/116) first.
