### PR TITLE
Simplify Request by removing generic version of factory methods

### DIFF
--- a/Sources/Get/Get.docc/Extensions/Request+Extension.md
+++ b/Sources/Get/Get.docc/Extensions/Request+Extension.md
@@ -23,7 +23,6 @@ Request<Repo>.patch(
 
 ### Initializers
 
-- ``init(method:path:query:headers:)``
 - ``init(method:path:query:body:headers:)``
 
 ### Instance Properties
@@ -37,13 +36,9 @@ Request<Repo>.patch(
 ### Type Method
 
 - ``get(_:query:headers:)``
-- ``post(_:query:headers:)``
 - ``post(_:query:body:headers:)``
-- ``put(_:query:headers:)``
 - ``put(_:query:body:headers:)``
-- ``patch(_:query:headers:)``
 - ``patch(_:query:body:headers:)``
-- ``delete(_:query:headers:)``
 - ``delete(_:query:body:headers:)``
 - ``head(_:query:headers:)``
 - ``options(_:query:headers:)``

--- a/Sources/Get/Request.swift
+++ b/Sources/Get/Request.swift
@@ -23,17 +23,8 @@ public struct Request<Response>: @unchecked Sendable {
 
     let body: AnyEncodable?
 
-    /// Initialiazes the request with the given parameters.
-    public init(method: String, path: String, query: [(String, String?)]? = nil, headers: [String: String]? = nil) {
-        self.method = method
-        self.path = path
-        self.query = query
-        self.headers = headers
-        self.body = nil
-    }
-
     /// Initialiazes the request with the given parameters and the request body.
-    public init<U: Encodable>(method: String, path: String, query: [(String, String?)]? = nil, body: U?, headers: [String: String]? = nil) {
+    public init(method: String, path: String, query: [(String, String?)]? = nil, body: Encodable? = nil, headers: [String: String]? = nil) {
         self.method = method
         self.path = path
         self.query = query
@@ -45,35 +36,19 @@ public struct Request<Response>: @unchecked Sendable {
         Request(method: "GET", path: path, query: query, headers: headers)
     }
 
-    public static func post(_ path: String, query: [(String, String?)]? = nil, headers: [String: String]? = nil) -> Request {
-        Request(method: "POST", path: path, query: query, headers: headers)
-    }
-
-    public static func post<U: Encodable>(_ path: String, query: [(String, String?)]? = nil, body: U?, headers: [String: String]? = nil) -> Request {
+    public static func post(_ path: String, query: [(String, String?)]? = nil, body: Encodable? = nil, headers: [String: String]? = nil) -> Request {
         Request(method: "POST", path: path, query: query, body: body, headers: headers)
     }
 
-    public static func put(_ path: String, query: [(String, String?)]? = nil, headers: [String: String]? = nil) -> Request {
-        Request(method: "PUT", path: path, query: query, headers: headers)
-    }
-
-    public static func put<U: Encodable>(_ path: String, query: [(String, String?)]? = nil, body: U?, headers: [String: String]? = nil) -> Request {
+    public static func put(_ path: String, query: [(String, String?)]? = nil, body: Encodable? = nil, headers: [String: String]? = nil) -> Request {
         Request(method: "PUT", path: path, query: query, body: body, headers: headers)
     }
 
-    public static func patch(_ path: String, query: [(String, String?)]? = nil, headers: [String: String]? = nil) -> Request {
-        Request(method: "PATCH", path: path, query: query, headers: headers)
-    }
-
-    public static func patch<U: Encodable>(_ path: String, query: [(String, String?)]? = nil, body: U?, headers: [String: String]? = nil) -> Request {
+    public static func patch(_ path: String, query: [(String, String?)]? = nil, body: Encodable? = nil, headers: [String: String]? = nil) -> Request {
         Request(method: "PATCH", path: path, query: query, body: body, headers: headers)
     }
 
-    public static func delete(_ path: String, query: [(String, String?)]? = nil, headers: [String: String]? = nil) -> Request {
-        Request(method: "DELETE", path: path, query: query, headers: headers)
-    }
-
-    public static func delete<U: Encodable>(_ path: String, query: [(String, String?)]? = nil, body: U?, headers: [String: String]? = nil) -> Request {
+    public static func delete(_ path: String, query: [(String, String?)]? = nil, body: Encodable? = nil, headers: [String: String]? = nil) -> Request {
         Request(method: "DELETE", path: path, query: query, body: body, headers: headers)
     }
 


### PR DESCRIPTION
Turns out, there is no need to use generics to make `AnyEncodable` work which trims down the number public of APIs nicely.