### PR TITLE
Revert back to supporting Swift 5.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,34 @@ on:
 
 jobs:
   macos-run-tests:
-    name: Unit Tests (iOS 15.4, Xcode 13.3.1)
-    runs-on: macOS-12
+    name: Unit Tests (Xcode ${{ matrix.xcode }})
+    strategy:
+      fail-fast: false
+      matrix:
+        xcode: ["13.4.1", "13.3.1", "13.2.1"]
+        include:
+          - xcode: "13.4.1"
+            macos: macOS-12
+          - xcode: "13.3.1"
+            macos: macOS-12
+          - xcode: "13.2.1"
+            macos: macOS-11
+    runs-on: ${{ matrix.macos }}
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.3.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
       - name: Run Tests
         run: swift test
 
   linux-run-tests:
-    name: Unit Tests (Linux)
+    name: Unit Tests (Linux, Swift ${{ matrix.swift }})
+    strategy:
+      fail-fast: false
+      matrix:
+        swift: ["5.5", "5.6"]
     runs-on: ubuntu-latest
+    container: swift:${{ matrix.swift }}
     steps:
       - uses: actions/checkout@v2
       - name: Run Tests

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
👋 

While working on CreateAPI/CreateAPI#83, I noticed that Xcode 13.2 tests failed because Get 1.0.0 bumped the Swift requirement up to 5.6. While I am not opposed to dropping support for older versions of Xcode, I don't want to do it if there isn't a good reason to.

I was going to tag you on the CreateAPI Pull Request, but I first wanted to check if the project still compiled using Xcode 13.2 since I didn't see any surrounding commits/discussion, and at this point, I thought it was just easier to raise a PR here instead 😄 

Anyway, my question is: Does Get _need_ to drop support for Swift 5.5 just yet? Even if we got at least one tagged release under 1.0.0, this would allow CreateAPI to require both Get 1.0.0 while still supporting Swift 5.5. 

If you are happy to keep it, I've included in this PR some updates to the CI checks to make sure that we test Swift 5.5 on both macOS and Linux. But equally, if there is a reason not to revert the change then I think I can just do the same over in CreateAPI as well. 

If you do merge this PR, would it be possible to tag a release over the next few days to unblock me? 

Thanks again! 