### PR TITLE
Fix withResponse() to respect the original method

### DIFF
--- a/Sources/Get/Request.swift
+++ b/Sources/Get/Request.swift
@@ -40,7 +40,7 @@ public struct Request<Response>: @unchecked Sendable {
         self.id = id
     }
 
-    /// Initialiazes the request with the given parameters.
+    /// Initializes the request with the given parameters.
     public init(
         path: String,
         method: HTTPMethod = .get,
@@ -59,7 +59,7 @@ public struct Request<Response>: @unchecked Sendable {
 
     private init(optionalUrl: URL?, method: HTTPMethod) {
         self.url = optionalUrl
-        self.method = .get
+        self.method = method
     }
 
     /// Changes the response type keeping the rest of the request parameters.


### PR DESCRIPTION
The `withResponse<T>(_ type: T.Type) -> Request<T>` method carries the comment:

> Changes the response type keeping the rest of the request parameters.

Based on this I assume I ran in to a bug — because the request method may also be altered. 

`withResponse` uses a private Initializer to create copy of the request with the updated return type. This initializer ignores the given `method` parameter and always sets the request to use the `.get` method.

This PR also includes a comment spelling fix.

 