### PR TITLE
Fixing Bearer authentication header references

### DIFF
--- a/Docs/Get.docc/Articles/authentication.md
+++ b/Docs/Get.docc/Articles/authentication.md
@@ -15,7 +15,7 @@ final class ClientDelegate: APIClientDelegate {
     private var accessToken: String = ""
 
     func client(_ client: APIClient, willSendRequest request: inout URLRequest) async throws {
-        request.setValue("Bearer: \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
     }
 }
 ```

--- a/Docs/Get.docc/Extensions/APIClient+Extension.md
+++ b/Docs/Get.docc/Extensions/APIClient+Extension.md
@@ -85,7 +85,7 @@ final class ClientDelegate: APIClientDelegate {
     private var accessToken: String = ""
 
     func client(_ client: APIClient, willSendRequest request: inout URLRequest) async throws {
-        request.setValue("Bearer: \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
     }
 
     func client(_ client: APIClient, shouldRetry task: URLSessionTask, error: Error, attempts: Int) async throws -> Bool {

--- a/Tests/GetTests/CodeSamplesTests.swift
+++ b/Tests/GetTests/CodeSamplesTests.swift
@@ -14,7 +14,7 @@ func checkSample01() {
         private var accessToken: String = ""
 
         func client(_ client: APIClient, willSendRequest request: inout URLRequest) async throws {
-            request.setValue("Bearer: \(accessToken)", forHTTPHeaderField: "Authorization")
+            request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         }
 
         func client(_ client: APIClient, shouldRetry task: URLSessionTask, error: Error, attempts: Int) async throws -> Bool {


### PR DESCRIPTION
Found a few references to `Authentication` header with the wrong `Bearer` value