### PR TITLE
Add delegate methods for per-request encoder and decoder

### DIFF
--- a/Sources/Get/APIClient.swift
+++ b/Sources/Get/APIClient.swift
@@ -14,8 +14,6 @@ public actor APIClient {
     /// The underlying `URLSession` instance.
     public nonisolated let session: URLSession
 
-    private let decoder: JSONDecoder
-    private let encoder: JSONEncoder
     private let delegate: APIClientDelegate
     private let dataLoader = DataLoader()
 
@@ -83,8 +81,6 @@ public actor APIClient {
         self.session = URLSession(configuration: configuration.sessionConfiguration, delegate: dataLoader, delegateQueue: delegateQueue)
         self.dataLoader.userSessionDelegate = configuration.sessionDelegate
         self.delegate = configuration.delegate ?? DefaultAPIClientDelegate()
-        self.decoder = configuration.decoder
-        self.encoder = configuration.encoder
     }
 
     // MARK: Sending Requests
@@ -104,6 +100,7 @@ public actor APIClient {
         configure: ((inout URLRequest) throws -> Void)? = nil
     ) async throws -> Response<T> {
         let response = try await data(for: request, delegate: delegate, configure: configure)
+        let decoder = self.delegate.client(self, decoderForRequest: request)
         let value: T = try await decode(response.data, using: decoder)
         return response.map { _ in value }
     }
@@ -221,6 +218,7 @@ public actor APIClient {
         configure: ((inout URLRequest) throws -> Void)? = nil
     ) async throws -> Response<T> {
         let response = try await _upload(for: request, fromFile: fileURL, delegate: delegate, configure: configure)
+        let decoder = self.delegate.client(self, decoderForRequest: request)
         let value: T = try await decode(response.data, using: decoder)
         return response.map { _ in value }
     }
@@ -283,6 +281,7 @@ public actor APIClient {
         configure: ((inout URLRequest) throws -> Void)? = nil
     ) async throws -> Response<T> {
         let response = try await _upload(for: request, from: data, delegate: delegate, configure: configure)
+        let decoder = self.delegate.client(self, decoderForRequest: request)
         let value: T = try await decode(response.data, using: decoder)
         return response.map { _ in value }
     }
@@ -342,6 +341,7 @@ public actor APIClient {
         urlRequest.allHTTPHeaderFields = request.headers
         urlRequest.httpMethod = request.method.rawValue
         if let body = request.body {
+            let encoder = delegate.client(self, encoderForRequest: request)
             urlRequest.httpBody = try await encode(body, using: encoder)
             if urlRequest.value(forHTTPHeaderField: "Content-Type") == nil &&
                 session.configuration.httpAdditionalHeaders?["Content-Type"] == nil {

--- a/Sources/Get/APIClientDelegate.swift
+++ b/Sources/Get/APIClientDelegate.swift
@@ -57,6 +57,27 @@ public protocol APIClientDelegate {
     /// - returns: The URL for the request. Return `nil` to use the default
     /// logic used by client.
     func client<T>(_ client: APIClient, makeURLForRequest request: Request<T>) throws -> URL?
+
+    /// Allows you to override the client's encoder for a specific request.
+    ///
+    /// If not implemented, the request uses the client's encoder.
+    ///
+    /// - Parameters:
+    ///   - client: The client that sends the request.
+    ///   - request: The request about to be sent.
+    /// - Returns: The JSONEncoder for the request.
+    func client<T>(_ client: APIClient, encoderForRequest request: Request<T>) -> JSONEncoder
+
+
+    /// Allows you to override the client's decoder for a specific request.
+    ///
+    /// If not implemented, the request uses the client's decoder.
+    ///
+    /// - Parameters:
+    ///   - client: The client that sends the request.
+    ///   - request: The request that was performed.
+    /// - Returns: The JSONDecoder for the request.
+    func client<T>(_ client: APIClient, decoderForRequest request: Request<T>) -> JSONDecoder
 }
 
 public extension APIClientDelegate {
@@ -76,6 +97,14 @@ public extension APIClientDelegate {
 
     func client<T>(_ client: APIClient, makeURLForRequest request: Request<T>) throws -> URL? {
         nil // Use default handlings
+    }
+
+    func client<T>(_ client: APIClient, encoderForRequest request: Request<T>) -> JSONEncoder {
+        return client.configuration.encoder
+    }
+
+    func client<T>(_ client: APIClient, decoderForRequest request: Request<T>) -> JSONDecoder {
+        return client.configuration.decoder
     }
 }
 

--- a/Sources/Get/APIClientDelegate.swift
+++ b/Sources/Get/APIClientDelegate.swift
@@ -60,24 +60,21 @@ public protocol APIClientDelegate {
 
     /// Allows you to override the client's encoder for a specific request.
     ///
-    /// If not implemented, the request uses the client's encoder.
-    ///
     /// - Parameters:
     ///   - client: The client that sends the request.
     ///   - request: The request about to be sent.
-    /// - Returns: The JSONEncoder for the request.
-    func client<T>(_ client: APIClient, encoderForRequest request: Request<T>) -> JSONEncoder
-
+    /// - Returns: The JSONEncoder for the request. Return `nil` to use the default
+    /// encoder set in the client.
+    func client<T>(_ client: APIClient, encoderForRequest request: Request<T>) -> JSONEncoder?
 
     /// Allows you to override the client's decoder for a specific request.
-    ///
-    /// If not implemented, the request uses the client's decoder.
     ///
     /// - Parameters:
     ///   - client: The client that sends the request.
     ///   - request: The request that was performed.
-    /// - Returns: The JSONDecoder for the request.
-    func client<T>(_ client: APIClient, decoderForRequest request: Request<T>) -> JSONDecoder
+    /// - Returns: The JSONDecoder for the request. Return `nil` to use the default
+    /// decoder set in the client.
+    func client<T>(_ client: APIClient, decoderForRequest request: Request<T>) -> JSONDecoder?
 }
 
 public extension APIClientDelegate {
@@ -99,12 +96,12 @@ public extension APIClientDelegate {
         nil // Use default handlings
     }
 
-    func client<T>(_ client: APIClient, encoderForRequest request: Request<T>) -> JSONEncoder {
-        return client.configuration.encoder
+    func client<T>(_ client: APIClient, encoderForRequest request: Request<T>) -> JSONEncoder? {
+        nil
     }
 
-    func client<T>(_ client: APIClient, decoderForRequest request: Request<T>) -> JSONDecoder {
-        return client.configuration.decoder
+    func client<T>(_ client: APIClient, decoderForRequest request: Request<T>) -> JSONDecoder? {
+        nil
     }
 }
 


### PR DESCRIPTION
As discussed in #61,  in some situations, we need an encoder or decoder for a specific request that differs from the underlying client's. This PR adds two delegate methods that allow you to override the encoder/decoder for a particular request. 