### PR TITLE
Fix Downloads Folder Path

### DIFF
--- a/Sources/Get/DataLoader.swift
+++ b/Sources/Get/DataLoader.swift
@@ -248,7 +248,7 @@ final class DataLoader: NSObject, URLSessionDataDelegate, URLSessionDownloadDele
         let handler = (handlers[downloadTask] as? DownloadTaskHandler)
         let downloadsURL = DataLoader.downloadDirectoryURL
         try? FileManager.default.createDirectory(at: downloadsURL, withIntermediateDirectories: true, attributes: nil)
-        let newLocation = downloadsURL.appendingPathExtension(location.lastPathComponent)
+        let newLocation = downloadsURL.appendingPathComponent(location.lastPathComponent)
         try? FileManager.default.moveItem(at: location, to: newLocation)
         handler?.location = newLocation
         handler?.downloadDelegate?.urlSession(session, downloadTask: downloadTask, didFinishDownloadingTo: newLocation)


### PR DESCRIPTION
I was implementing file downloads into my app and noticed that the temporary directory was not being cleared, even though `DataLoader` should do so. Download file paths were not created properly and instead were formatted as such:

`/private/.../tmp/com.github.kean.get/Downloads.foo-bar.tmp`

This fixes downloads so that they properly download into the `tmp/com.github.kean.get/Downloads/` folder and can be cleared. 

However, pre-existing downloads still act as memory zombies in `tmp/com.github.kean.get/` and will require manual deletion.