### PR TITLE
DataLoader: don't wrap an already Encodable value in AnyEncodable

### DIFF
--- a/Sources/Get/DataLoader.swift
+++ b/Sources/Get/DataLoader.swift
@@ -357,7 +357,7 @@ func encode(_ value: Encodable, using encoder: JSONEncoder) async throws -> Data
         return string.data(using: .utf8)
     } else {
         return try await Task.detached {
-            try encoder.encode(AnyEncodable(value: value))
+            try encoder.encode(value)
         }.value
     }
 }


### PR DESCRIPTION
i don't understand what this extra wrap does. the value is already `Encodable` so it should be possible to directly encode it